### PR TITLE
reference submodule by https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "eda-decision-environment"]
 	path = eda-decision-environment
-	url = git@github.com:kubealex/eda-decision-environment.git
+	url = https://github.com/kubealex/eda-decision-environment.git


### PR DESCRIPTION
I could not create project when running 

```bash
ansible-navigator run --ee false configure-use-case.yml -e @use-cases/use-case-alertmanager-setup.yml
```

when running on demo AAP Controller without github ssh configured. 